### PR TITLE
fix: use card payment method instead of checkoutcom-flow

### DIFF
--- a/server-actions/createOrder.ts
+++ b/server-actions/createOrder.ts
@@ -51,7 +51,7 @@ export async function createOrder({
           },
         ],
         payment: {
-          method: "checkoutcom-flow",
+          method: "card",
           receiptEmail,
         },
         recipient: {


### PR DESCRIPTION
## Summary

Changes `payment.method` in `server-actions/createOrder.ts` from `checkoutcom-flow` to `card`. Mirrors [Crossmint/onramp-embedded-quickstart#6](https://github.com/Crossmint/onramp-embedded-quickstart/pull/6), which made the same class of change (`basis-theory` → `card`) on Jan 19, 2026.

## Symptom

The deposit flow in this starter app currently declines every card with a generic "Payment declined — try again or use another payment method", including the test card `4242 4242 4242 4242` advertised in the deposit UI itself.

## Root cause

The embedded checkout iframe, when given `payment.method: "checkoutcom-flow"`, renders **only** card number / expiry / CVV — no billing-address fields. Checkout.com's risk engine then declines the payment with:

```json
{
  "id": "pay_...",
  "status": "Declined",
  "type": "card",
  "decline_reason": "invalid_customer_data"
}
```

The Checkout WebComponents payload includes the feature flag `use_billing_address_from_config_for_tokenization` but no `customer` or `billing_address` block — strong hint that the SDK expects the higher-level `"card"` method to inject these.

`"checkoutcom-flow"` is not listed in the [Create Order API reference](https://docs.crossmint.com/api-reference/headless/create-order) or in the [React Onramp Quickstart](https://docs.crossmint.com/onramp/quickstarts/react). Only `"card"` is documented for fiat, and the sibling onramp demo uses `"card"` since Jan 19.

## Fix

```diff
 payment: {
-  method: "checkoutcom-flow",
+  method: "card",
   receiptEmail,
 },
```

## Test plan

- [ ] Run locally with `NEXT_PUBLIC_CROSSMINT_CLIENT_API_KEY` and `CROSSMINT_SERVER_SIDE_API_KEY` set to staging keys
- [ ] Sign in, hit Deposit, enter $5
- [ ] Verify the embedded checkout now renders the billing-address fields alongside the card form
- [ ] Pay with `4242 4242 4242 4242` and confirm the order completes

## Follow-ups worth tracking separately

- README `Setup` section never mentions `CROSSMINT_SERVER_SIDE_API_KEY` even though `createOrder` requires it — devs hit "Server misconfiguration" error mid-deposit.
- README says `npm install` first but only `pnpm-lock.yaml` is shipped.
- Yield section in README intro doesn't mention the required `NEXT_PUBLIC_YIELD_API_KEY` (from yield.xyz). Without it, the UI shows the misleading "No yield opportunities available for this network."
- Deposit UI shows generic "Payment declined" with no `decline_reason` — surfacing the underlying error would make this kind of config issue self-diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/fintech-starter-app/pull/24" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->