### PR TITLE
fix: activity feed deduping, labeling, and auto-refresh

### DIFF
--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -33,12 +33,7 @@ const getActivityTitle = (eventType: string | undefined, isOutgoing: boolean) =>
   if (eventType?.toLowerCase().includes("yield")) return "Yield";
   if (eventType?.toLowerCase().includes("cancel")) return "Transfer canceled";
   if (eventType?.toLowerCase().includes("fail")) return "Transfer failed";
-  // NOTE: "wallets.deposit.onramp" is not currently emitted by the API.
-  // Kept here for forward-compatibility — when the wallets-transfers API
-  // adds an onramp discriminator we can label real onramps as "Deposit".
   if (eventType === "wallets.deposit.onramp") return "Deposit";
-  // For incoming records where the sender is also us (a self-send that the
-  // API mis-labels as `.in`), let the outgoing branch handle labeling.
   if (eventType === "wallets.transfer.in" && !isOutgoing) return "Received";
   return isOutgoing ? "Sent" : "Received";
 };

--- a/components/ActivityFeed.tsx
+++ b/components/ActivityFeed.tsx
@@ -33,8 +33,13 @@ const getActivityTitle = (eventType: string | undefined, isOutgoing: boolean) =>
   if (eventType?.toLowerCase().includes("yield")) return "Yield";
   if (eventType?.toLowerCase().includes("cancel")) return "Transfer canceled";
   if (eventType?.toLowerCase().includes("fail")) return "Transfer failed";
+  // NOTE: "wallets.deposit.onramp" is not currently emitted by the API.
+  // Kept here for forward-compatibility — when the wallets-transfers API
+  // adds an onramp discriminator we can label real onramps as "Deposit".
   if (eventType === "wallets.deposit.onramp") return "Deposit";
-  if (eventType === "wallets.transfer.in") return "Received";
+  // For incoming records where the sender is also us (a self-send that the
+  // API mis-labels as `.in`), let the outgoing branch handle labeling.
+  if (eventType === "wallets.transfer.in" && !isOutgoing) return "Received";
   return isOutgoing ? "Sent" : "Received";
 };
 

--- a/hooks/useActivityFeed.ts
+++ b/hooks/useActivityFeed.ts
@@ -29,11 +29,26 @@ function yieldActionToActivityEvent(action: YieldAction): ActivityEvent {
 export function useActivityFeed() {
   const { wallet } = useWallet();
 
-  // Fetch wallet activity
+  // Fetch wallet activity.
+  //
+  // We poll every 5s while the dashboard is mounted so the feed picks up new
+  // transfers after a send/onramp without the user having to manually refresh.
+  // Sends and onramps both call `refetch` synchronously when they complete, but
+  // that immediate refetch races the Crossmint indexer — the just-broadcast tx
+  // isn't yet visible as `status: succeeded`. Background polling bridges the
+  // gap until the indexer catches up.
+  //
+  // Also catches external transfers (someone sending you USDC from outside the
+  // app), which a "trigger-after-send" approach would miss.
+  //
+  // `refetchIntervalInBackground: false` pauses polling when the tab is hidden,
+  // so we don't burn requests while the user is away.
   const walletActivityQuery = useQuery({
     queryKey: ["walletActivity", wallet?.address],
     queryFn: async () => await wallet?.transfers({ tokens: "usdc", status: "successful" }),
     enabled: !!wallet?.address,
+    refetchInterval: 5_000,
+    refetchIntervalInBackground: false,
   });
 
   // Fetch yield actions - uses same query key as useYieldPositions for cache sharing
@@ -46,27 +61,31 @@ export function useActivityFeed() {
 
   // Combine and sort events
   const combinedEvents = (() => {
-    // Map V1 transfers to ActivityEvent format
-    const walletEvents: ActivityEvent[] = (walletActivityQuery.data?.data || []).map((tx: any) => {
-      const senderAddr = (tx.sender?.address || "").toLowerCase();
-      const recipientAddr = (tx.recipient?.address || "").toLowerCase();
-      const isSelfTransfer = senderAddr === recipientAddr;
-
-      // Differentiate onramp deposits (self-transfer) from received funds (external sender)
-      let type = tx.type || "";
-      if (type === "wallets.transfer.in" && isSelfTransfer) {
-        type = "wallets.deposit.onramp";
-      }
-
-      return {
-        from_address: tx.sender?.address || "",
-        to_address: tx.recipient?.address,
-        timestamp: new Date(tx.completedAt).getTime(),
-        type,
-        amount: tx.token?.amount || "0",
-        token_symbol: tx.token?.symbol,
-      };
+    // Map V1 transfers to ActivityEvent format.
+    //
+    // Defensive dedupe: the Crossmint wallets-transfers API currently returns
+    // two byte-identical records for a self-send (sender == recipient). The
+    // chain only emits one ERC-20 Transfer event; this is a server-side bug.
+    // We collapse by transferId so the UI shows a single row.
+    //
+    // We rely on the API's `type` field directly ("wallets.transfer.in" /
+    // "wallets.transfer.out") — the previous "self-transfer => onramp"
+    // heuristic was conceptually inverted (onramps come from an EXTERNAL
+    // sender, not a self-transfer) and is removed.
+    const rawTransfers = walletActivityQuery.data?.data || [];
+    const dedupedTransfers = rawTransfers.filter((tx: any, i: number, arr: any[]) => {
+      if (!tx.transferId) return true; // keep records that lack a transferId (e.g., onramps)
+      return arr.findIndex((o: any) => o.transferId === tx.transferId) === i;
     });
+
+    const walletEvents: ActivityEvent[] = dedupedTransfers.map((tx: any) => ({
+      from_address: tx.sender?.address || "",
+      to_address: tx.recipient?.address,
+      timestamp: new Date(tx.completedAt).getTime(),
+      type: tx.type || "",
+      amount: tx.token?.amount || "0",
+      token_symbol: tx.token?.symbol,
+    }));
 
     // Transform yield actions to activity events
     const yieldEvents: ActivityEvent[] = (yieldActionsQuery.data || []).map(

--- a/hooks/useActivityFeed.ts
+++ b/hooks/useActivityFeed.ts
@@ -29,20 +29,6 @@ function yieldActionToActivityEvent(action: YieldAction): ActivityEvent {
 export function useActivityFeed() {
   const { wallet } = useWallet();
 
-  // Fetch wallet activity.
-  //
-  // We poll every 5s while the dashboard is mounted so the feed picks up new
-  // transfers after a send/onramp without the user having to manually refresh.
-  // Sends and onramps both call `refetch` synchronously when they complete, but
-  // that immediate refetch races the Crossmint indexer — the just-broadcast tx
-  // isn't yet visible as `status: succeeded`. Background polling bridges the
-  // gap until the indexer catches up.
-  //
-  // Also catches external transfers (someone sending you USDC from outside the
-  // app), which a "trigger-after-send" approach would miss.
-  //
-  // `refetchIntervalInBackground: false` pauses polling when the tab is hidden,
-  // so we don't burn requests while the user is away.
   const walletActivityQuery = useQuery({
     queryKey: ["walletActivity", wallet?.address],
     queryFn: async () => await wallet?.transfers({ tokens: "usdc", status: "successful" }),
@@ -61,20 +47,9 @@ export function useActivityFeed() {
 
   // Combine and sort events
   const combinedEvents = (() => {
-    // Map V1 transfers to ActivityEvent format.
-    //
-    // Defensive dedupe: the Crossmint wallets-transfers API currently returns
-    // two byte-identical records for a self-send (sender == recipient). The
-    // chain only emits one ERC-20 Transfer event; this is a server-side bug.
-    // We collapse by transferId so the UI shows a single row.
-    //
-    // We rely on the API's `type` field directly ("wallets.transfer.in" /
-    // "wallets.transfer.out") — the previous "self-transfer => onramp"
-    // heuristic was conceptually inverted (onramps come from an EXTERNAL
-    // sender, not a self-transfer) and is removed.
     const rawTransfers = walletActivityQuery.data?.data || [];
     const dedupedTransfers = rawTransfers.filter((tx: any, i: number, arr: any[]) => {
-      if (!tx.transferId) return true; // keep records that lack a transferId (e.g., onramps)
+      if (!tx.transferId) return true;
       return arr.findIndex((o: any) => o.transferId === tx.transferId) === i;
     });
 


### PR DESCRIPTION
## Summary

Three related fixes to the dashboard activity feed, plus an auto-refresh:

1. **Dedupe duplicate self-send rows** (defensive workaround for a Crossmint wallets-transfers API bug — see notes below).
2. **Remove the inverted "self-transfer ⇒ onramp" heuristic**, which was causing real onramps to show as "Received" and self-sends to show as "Deposit".
3. **Narrow `wallets.transfer.in` ⇒ "Received"** to non-outgoing only, so self-sends fall through to "Sent" instead of contradicting their own minus sign.
4. **Auto-refresh the activity feed** every 5s while the dashboard is mounted, so new transfers appear without the user having to manually refresh after a send/onramp.

## End-state behavior

| Scenario | Before | After |
|---|---|---|
| Send to a different wallet | "Sent −$X.XX" | "Sent −$X.XX" (unchanged) |
| Receive from external (including onramp) | "Received +$X.XX" | "Received +$X.XX" (unchanged) |
| Send to yourself | "Deposit −$X.XX" × **2 duplicate rows** | "Sent −$X.XX" × **1 row** ✅ |
| New tx after send/onramp | Required manual refresh | Appears within ~5s ✅ |

## Notes on the self-send duplication

The wallets-transfers endpoint (`GET /unstable/wallets/{walletLocator}/transfers`) currently returns two byte-identical records for a self-send — same `transferId`, same `onChain.txId`, both typed `wallets.transfer.in` — even though the chain only emits one ERC-20 `Transfer` event (verified via basescan). The duplication originates in the indexer, not the SDK or this app. We have a bug report filed for the wallets API team. Until that's fixed server-side, this PR defensively collapses by `transferId` so the UI doesn't show two rows for one transfer.

The dedupe is **a no-op once the API is fixed** — it only collapses records that share a `transferId`, which is exactly when the API is misbehaving.

## Notes on onramp labeling

The user wanted "Deposit" for onramps and "Received" for ordinary crypto receives. **The wallets-transfers API doesn't currently expose any field that distinguishes the two** — no `source`, no `relatedOrderId`, no metadata. With no discriminator we can't reliably tell them apart, so all external-incoming is labeled "Received".

The `wallets.deposit.onramp` → "Deposit" mapping is kept in `ActivityFeed.tsx` (gated on a type the API doesn't currently emit) as forward-compatibility: when the API exposes an onramp discriminator the hook can start setting that type and the label will switch over automatically.

A follow-up to the API team to add an onramp discriminator would unlock the right behavior here.

## Design choice for auto-refresh

I picked background polling (`refetchInterval: 5_000`) over triggered polling because:

- The hook is mounted inside the send/deposit modals, which unmount immediately after completion. Any polling started in the modal would die on unmount.
- Triggered polling would also miss external transfers (someone sending USDC from outside the app), which background polling catches for free.
- Cost is ~1 small GET request every 5s while the dashboard tab is active. `refetchIntervalInBackground: false` pauses when the tab is hidden.

If 5s latency is too slow later, the upgrade path is to lift polling state to a dashboard-level context and drop the interval to 1s for a 30s window after triggered events. That's a bigger refactor and not warranted right now.

## Test plan

- [ ] Sign in, click Send, send USDC to your own wallet address → exactly one "Sent −\$X" row appears within ~5s (previously: two "Deposit" rows after manual refresh).
- [ ] Click Send, send USDC to a different address → one "Sent −\$X" row appears within ~5s.
- [ ] Click Deposit, complete an onramp (with PR #24 also applied) → one "Received +\$X" row appears within ~5s.
- [ ] Hide the tab → polling stops in the network panel. Switch back → polling resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://crossmint.devinenterprise.com/review/crossmint/fintech-starter-app/pull/25" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->