### PR TITLE
fix: resolve UX/layout issues in onramp deposit modal

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -91,11 +91,11 @@
 }
 
 .checkout-container {
-  min-height: 480px;
+  min-height: 620px;
   position: relative;
 }
 
 .checkout-container iframe {
   width: 100%;
-  min-height: 460px;
+  min-height: 600px;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,7 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: #13b601;
+  --primary: #13B601;
   --primary-hover: #26a64b;
   --primary-foreground: oklch(100% 0 0);
   --secondary: #000000;
@@ -88,15 +88,4 @@
   [role="button"]:not([disabled]) {
     cursor: pointer;
   }
-}
-
-/* Embedded checkout container — ensure adequate height to prevent overlap */
-.checkout-container {
-  min-height: 380px;
-  position: relative;
-}
-
-.checkout-container iframe {
-  width: 100%;
-  min-height: 360px;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,3 +89,13 @@
     cursor: pointer;
   }
 }
+
+.checkout-container {
+  min-height: 380px;
+  position: relative;
+}
+
+.checkout-container iframe {
+  width: 100%;
+  min-height: 360px;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -90,35 +90,12 @@
   }
 }
 
-/* Always show a visible scrollbar in the deposit modal */
-[data-slot="dialog"] [data-state] {
-  scrollbar-width: thin;
-  scrollbar-color: #c4c4c4 transparent;
-}
-
-[data-slot="dialog"] [data-state]::-webkit-scrollbar {
-  width: 6px;
-}
-
-[data-slot="dialog"] [data-state]::-webkit-scrollbar-track {
-  background: transparent;
-}
-
-[data-slot="dialog"] [data-state]::-webkit-scrollbar-thumb {
-  background-color: #c4c4c4;
-  border-radius: 3px;
-}
-
-[data-slot="dialog"] [data-state]::-webkit-scrollbar-thumb:hover {
-  background-color: #a0a0a0;
-}
-
 .checkout-container {
-  min-height: 380px;
+  min-height: 480px;
   position: relative;
 }
 
 .checkout-container iframe {
   width: 100%;
-  min-height: 360px;
+  min-height: 460px;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -90,6 +90,29 @@
   }
 }
 
+/* Always show a visible scrollbar in the deposit modal */
+[data-slot="dialog"] [data-state] {
+  scrollbar-width: thin;
+  scrollbar-color: #c4c4c4 transparent;
+}
+
+[data-slot="dialog"] [data-state]::-webkit-scrollbar {
+  width: 6px;
+}
+
+[data-slot="dialog"] [data-state]::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+[data-slot="dialog"] [data-state]::-webkit-scrollbar-thumb {
+  background-color: #c4c4c4;
+  border-radius: 3px;
+}
+
+[data-slot="dialog"] [data-state]::-webkit-scrollbar-thumb:hover {
+  background-color: #a0a0a0;
+}
+
 .checkout-container {
   min-height: 380px;
   position: relative;

--- a/app/globals.css
+++ b/app/globals.css
@@ -89,13 +89,3 @@
     cursor: pointer;
   }
 }
-
-.checkout-container {
-  min-height: 620px;
-  position: relative;
-}
-
-.checkout-container iframe {
-  width: 100%;
-  min-height: 600px;
-}

--- a/app/globals.css
+++ b/app/globals.css
@@ -9,7 +9,7 @@
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
   --popover-foreground: oklch(0.145 0 0);
-  --primary: #13B601;
+  --primary: #13b601;
   --primary-hover: #26a64b;
   --primary-foreground: oklch(100% 0 0);
   --secondary: #000000;
@@ -88,4 +88,15 @@
   [role="button"]:not([disabled]) {
     cursor: pointer;
   }
+}
+
+/* Embedded checkout container — ensure adequate height to prevent overlap */
+.checkout-container {
+  min-height: 380px;
+  position: relative;
+}
+
+.checkout-container iframe {
+  width: 100%;
+  min-height: 360px;
 }

--- a/components/deposit/AmountBreakdown.tsx
+++ b/components/deposit/AmountBreakdown.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 const LOADING_TIMEOUT_MS = 5000;
-const ESTIMATED_FEE_PERCENT = 0.035; // ~3.5% variable fee
-const ESTIMATED_FEE_FIXED = 0.3; // ~$0.30 fixed processing fee
+const ESTIMATED_FEE_PERCENT = 0.029; // ~2.9% variable fee (US debit baseline)
+const ESTIMATED_FEE_FIXED = 0.99; // ~$0.99 flat processing fee
 
 interface BreakdownElementProps {
   label: string;

--- a/components/deposit/AmountBreakdown.tsx
+++ b/components/deposit/AmountBreakdown.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useRef, useState } from "react";
 
 const LOADING_TIMEOUT_MS = 5000;
-const ESTIMATED_FEE_RATE = 0.05; // ~5% estimated fee for sandbox display
+const ESTIMATED_FEE_PERCENT = 0.035; // ~3.5% variable fee
+const ESTIMATED_FEE_FIXED = 0.3; // ~$0.30 fixed processing fee
 
 interface BreakdownElementProps {
   label: string;
@@ -47,6 +48,7 @@ interface AmountBreakdownProps {
 export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBreakdownProps) {
   const [timedOut, setTimedOut] = useState(false);
   const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasQuote = quote != null;
 
   const quoteAmount =
     quote?.totalPrice?.amount && isAmountValid ? Number.parseFloat(quote?.totalPrice?.amount) : 0;
@@ -55,7 +57,7 @@ export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBre
       ? Number.parseFloat(quote?.quantityRange?.upperBound)
       : 0;
 
-  const isWaitingForQuote = inputAmount !== quoteAmount && isAmountValid;
+  const isWaitingForQuote = hasQuote && inputAmount !== quoteAmount && isAmountValid;
 
   useEffect(() => {
     if (isWaitingForQuote) {
@@ -70,23 +72,18 @@ export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBre
     };
   }, [isWaitingForQuote, inputAmount]);
 
-  // Use quote values if available, otherwise fall back to estimates after timeout.
-  // In sandbox the quote may resolve but return zero fees (totalPrice == upperBound),
-  // which is unrealistic for a demo — apply estimated fees in that case too.
-  const useEstimates = timedOut && isWaitingForQuote;
+  // When no quote is provided (pre-confirmation), show estimates immediately.
+  // When quote exists but returns zero fees (sandbox: totalPrice == upperBound),
+  // also apply estimated fees since $0 fees is unrealistic for a demo.
+  const quoteTimedOut = timedOut && isWaitingForQuote;
   const quoteFees = quoteAmount ? quoteAmount - quoteTotal : 0;
   const hasRealisticFees = quoteFees > 0;
+  const shouldEstimate = !hasQuote || quoteTimedOut || (quoteAmount > 0 && !hasRealisticFees);
 
-  const amount = useEstimates ? inputAmount : quoteAmount;
-  const fees =
-    useEstimates || (quoteAmount > 0 && !hasRealisticFees)
-      ? inputAmount * ESTIMATED_FEE_RATE
-      : quoteFees;
-  const total =
-    useEstimates || (quoteAmount > 0 && !hasRealisticFees)
-      ? inputAmount * (1 - ESTIMATED_FEE_RATE)
-      : quoteTotal;
-  const showEstimateMarker = useEstimates || (quoteAmount > 0 && !hasRealisticFees);
+  const estimatedFees = inputAmount * ESTIMATED_FEE_PERCENT + ESTIMATED_FEE_FIXED;
+  const amount = shouldEstimate ? inputAmount : quoteAmount;
+  const fees = shouldEstimate ? estimatedFees : quoteFees;
+  const total = shouldEstimate ? inputAmount - estimatedFees : quoteTotal;
   const isLoading = isWaitingForQuote && !timedOut;
 
   return (
@@ -95,21 +92,21 @@ export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBre
         label="Amount"
         value={amount}
         isLoading={isLoading}
-        isEstimate={showEstimateMarker}
+        isEstimate={shouldEstimate}
       />
       <BreakdownElement
         label="Trans. Fees"
         value={fees}
         isLoading={isLoading}
-        isEstimate={showEstimateMarker}
+        isEstimate={shouldEstimate}
       />
       <BreakdownElement
         label="Total add to wallet"
         value={total}
         isLoading={isLoading}
-        isEstimate={showEstimateMarker}
+        isEstimate={shouldEstimate}
       />
-      {showEstimateMarker && (
+      {shouldEstimate && (
         <p className="text-xs text-gray-400">
           Estimated values — final amount determined at checkout
         </p>

--- a/components/deposit/AmountBreakdown.tsx
+++ b/components/deposit/AmountBreakdown.tsx
@@ -70,15 +70,23 @@ export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBre
     };
   }, [isWaitingForQuote, inputAmount]);
 
-  // Use quote values if available, otherwise fall back to estimates after timeout
+  // Use quote values if available, otherwise fall back to estimates after timeout.
+  // In sandbox the quote may resolve but return zero fees (totalPrice == upperBound),
+  // which is unrealistic for a demo — apply estimated fees in that case too.
   const useEstimates = timedOut && isWaitingForQuote;
+  const quoteFees = quoteAmount ? quoteAmount - quoteTotal : 0;
+  const hasRealisticFees = quoteFees > 0;
+
   const amount = useEstimates ? inputAmount : quoteAmount;
-  const fees = useEstimates
-    ? inputAmount * ESTIMATED_FEE_RATE
-    : quoteAmount
-      ? quoteAmount - quoteTotal
-      : 0;
-  const total = useEstimates ? inputAmount * (1 - ESTIMATED_FEE_RATE) : quoteTotal;
+  const fees =
+    useEstimates || (quoteAmount > 0 && !hasRealisticFees)
+      ? inputAmount * ESTIMATED_FEE_RATE
+      : quoteFees;
+  const total =
+    useEstimates || (quoteAmount > 0 && !hasRealisticFees)
+      ? inputAmount * (1 - ESTIMATED_FEE_RATE)
+      : quoteTotal;
+  const showEstimateMarker = useEstimates || (quoteAmount > 0 && !hasRealisticFees);
   const isLoading = isWaitingForQuote && !timedOut;
 
   return (
@@ -87,21 +95,21 @@ export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBre
         label="Amount"
         value={amount}
         isLoading={isLoading}
-        isEstimate={useEstimates}
+        isEstimate={showEstimateMarker}
       />
       <BreakdownElement
         label="Trans. Fees"
         value={fees}
         isLoading={isLoading}
-        isEstimate={useEstimates}
+        isEstimate={showEstimateMarker}
       />
       <BreakdownElement
         label="Total add to wallet"
         value={total}
         isLoading={isLoading}
-        isEstimate={useEstimates}
+        isEstimate={showEstimateMarker}
       />
-      {useEstimates && (
+      {showEstimateMarker && (
         <p className="text-xs text-gray-400">
           Estimated values — final amount determined at checkout
         </p>

--- a/components/deposit/AmountBreakdown.tsx
+++ b/components/deposit/AmountBreakdown.tsx
@@ -1,18 +1,27 @@
+import { useEffect, useRef, useState } from "react";
+
+const LOADING_TIMEOUT_MS = 5000;
+const ESTIMATED_FEE_RATE = 0.05; // ~5% estimated fee for sandbox display
+
 interface BreakdownElementProps {
   label: string;
   value: string | number;
   isLoading?: boolean;
+  isEstimate?: boolean;
 }
 
-function BreakdownElement({ label, value, isLoading }: BreakdownElementProps) {
+function BreakdownElement({ label, value, isLoading, isEstimate }: BreakdownElementProps) {
   return (
     <div className="flex justify-between text-sm">
       <span className="text-gray-900">{label}</span>
-      <span className="flex items-center font-medium text-gray-900">
+      <span className="flex items-center gap-1 font-medium text-gray-900">
         {isLoading ? (
           <div className="border-primary h-3 w-3 animate-spin rounded-full border-2 border-t-transparent" />
         ) : (
-          `$${typeof value === "number" ? value.toFixed(2) : value}`
+          <>
+            {isEstimate && <span className="text-xs font-normal text-gray-400">~</span>}
+            {`$${typeof value === "number" ? value.toFixed(2) : value}`}
+          </>
         )}
       </span>
     </div>
@@ -36,21 +45,67 @@ interface AmountBreakdownProps {
 }
 
 export function AmountBreakdown({ quote, inputAmount, isAmountValid }: AmountBreakdownProps) {
-  const amount =
+  const [timedOut, setTimedOut] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const quoteAmount =
     quote?.totalPrice?.amount && isAmountValid ? Number.parseFloat(quote?.totalPrice?.amount) : 0;
-  const total =
-    amount && quote?.quantityRange?.upperBound && isAmountValid
+  const quoteTotal =
+    quoteAmount && quote?.quantityRange?.upperBound && isAmountValid
       ? Number.parseFloat(quote?.quantityRange?.upperBound)
       : 0;
-  const fees = amount ? amount - total : 0;
 
-  const isLoading = inputAmount !== amount && isAmountValid;
+  const isWaitingForQuote = inputAmount !== quoteAmount && isAmountValid;
+
+  useEffect(() => {
+    if (isWaitingForQuote) {
+      setTimedOut(false);
+      timeoutRef.current = setTimeout(() => setTimedOut(true), LOADING_TIMEOUT_MS);
+    } else {
+      setTimedOut(false);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    }
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, [isWaitingForQuote, inputAmount]);
+
+  // Use quote values if available, otherwise fall back to estimates after timeout
+  const useEstimates = timedOut && isWaitingForQuote;
+  const amount = useEstimates ? inputAmount : quoteAmount;
+  const fees = useEstimates
+    ? inputAmount * ESTIMATED_FEE_RATE
+    : quoteAmount
+      ? quoteAmount - quoteTotal
+      : 0;
+  const total = useEstimates ? inputAmount * (1 - ESTIMATED_FEE_RATE) : quoteTotal;
+  const isLoading = isWaitingForQuote && !timedOut;
 
   return (
     <div className="flex w-full flex-col gap-3 rounded-xl border border-gray-200 p-4">
-      <BreakdownElement label="Amount" value={amount} isLoading={isLoading} />
-      <BreakdownElement label="Trans. Fees" value={fees} isLoading={isLoading} />
-      <BreakdownElement label="Total add to wallet" value={total} isLoading={isLoading} />
+      <BreakdownElement
+        label="Amount"
+        value={amount}
+        isLoading={isLoading}
+        isEstimate={useEstimates}
+      />
+      <BreakdownElement
+        label="Trans. Fees"
+        value={fees}
+        isLoading={isLoading}
+        isEstimate={useEstimates}
+      />
+      <BreakdownElement
+        label="Total add to wallet"
+        value={total}
+        isLoading={isLoading}
+        isEstimate={useEstimates}
+      />
+      {useEstimates && (
+        <p className="text-xs text-gray-400">
+          Estimated values — final amount determined at checkout
+        </p>
+      )}
     </div>
   );
 }

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -190,7 +190,6 @@ export function Checkout({
                   />
                 </div>
               )}
-              <div className="checkout-container">
               <CrossmintEmbeddedCheckout
                 orderId={orderId}
                 // @ts-ignore
@@ -203,7 +202,6 @@ export function Checkout({
                 }}
                 appearance={CHECKOUT_APPEARANCE}
               />
-              </div>
             </div>
           )}
         </div>

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { CrossmintEmbeddedCheckout, useCrossmintCheckout } from "@crossmint/client-sdk-react-ui";
 import { CreditCard } from "lucide-react";
 import { cn } from "@/lib/utils";
@@ -112,7 +112,6 @@ export function Checkout({
   const [clientSecret, setClientSecret] = useState<string>("");
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
   const [orderError, setOrderError] = useState<string>("");
-  const orderAmountRef = useRef<string>("");
 
   const handleCreateOrder = async () => {
     if (!amount || !isAmountValid || !receiptEmail || !walletAddress) return;
@@ -133,7 +132,6 @@ export function Checkout({
 
       setOrderId(result.data.order.orderId);
       setClientSecret(result.data.clientSecret);
-      orderAmountRef.current = amount;
     } catch (error) {
       console.error("Error creating order:", error);
       setOrderError(error instanceof Error ? error.message : "Failed to create order");
@@ -180,9 +178,9 @@ export function Checkout({
             </div>
           )}
           {orderId && clientSecret && !isCreatingOrder && (
-            <div className="flex flex-col gap-3">
+            <div>
               {step === "options" && (
-                <div className="flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
+                <div className="mb-4 flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
                   <CreditCard className="h-4 w-4 flex-shrink-0 text-gray-500" />
                   <span className="text-xs text-gray-600">Test card:</span>
                   <code className="text-xs font-medium text-gray-800">4242 4242 4242 4242</code>
@@ -192,20 +190,18 @@ export function Checkout({
                   />
                 </div>
               )}
-              <div className="checkout-container overflow-hidden rounded-xl">
-                <CrossmintEmbeddedCheckout
-                  orderId={orderId}
-                  // @ts-ignore
-                  clientSecret={clientSecret}
-                  payment={{
-                    receiptEmail,
-                    crypto: { enabled: false },
-                    fiat: { enabled: true },
-                    defaultMethod: "fiat",
-                  }}
-                  appearance={CHECKOUT_APPEARANCE}
-                />
-              </div>
+              <CrossmintEmbeddedCheckout
+                orderId={orderId}
+                // @ts-ignore
+                clientSecret={clientSecret}
+                payment={{
+                  receiptEmail,
+                  crypto: { enabled: false },
+                  fiat: { enabled: true },
+                  defaultMethod: "fiat",
+                }}
+                appearance={CHECKOUT_APPEARANCE}
+              />
             </div>
           )}
         </div>

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -190,6 +190,7 @@ export function Checkout({
                   />
                 </div>
               )}
+              <div className="checkout-container">
               <CrossmintEmbeddedCheckout
                 orderId={orderId}
                 // @ts-ignore
@@ -202,6 +203,7 @@ export function Checkout({
                 }}
                 appearance={CHECKOUT_APPEARANCE}
               />
+              </div>
             </div>
           )}
         </div>

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { CrossmintEmbeddedCheckout, useCrossmintCheckout } from "@crossmint/client-sdk-react-ui";
-import { CreditCard } from "lucide-react";
+import { CreditCard, Info } from "lucide-react";
 import { AmountBreakdown } from "./AmountBreakdown";
 import { cn } from "@/lib/utils";
 import { createOrder } from "@/server-actions/createOrder";
@@ -58,6 +58,7 @@ const CHECKOUT_APPEARANCE = {
       font: {
         family: "Inter, sans-serif",
       },
+      borderRadius: "9999px",
       colors: {
         background: primaryColor,
       },
@@ -112,6 +113,9 @@ export function Checkout({
   const [clientSecret, setClientSecret] = useState<string>("");
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
   const [orderError, setOrderError] = useState<string>("");
+  const [showCardHelper, setShowCardHelper] = useState(true);
+  const [checkoutPhase, setCheckoutPhase] = useState<string>("");
+  const orderAmountRef = useRef<string>("");
 
   const handleCreateOrder = async () => {
     if (!amount || !isAmountValid || !receiptEmail || !walletAddress) return;
@@ -132,6 +136,7 @@ export function Checkout({
 
       setOrderId(result.data.order.orderId);
       setClientSecret(result.data.clientSecret);
+      orderAmountRef.current = amount;
     } catch (error) {
       console.error("Error creating order:", error);
       setOrderError(error instanceof Error ? error.message : "Failed to create order");
@@ -153,7 +158,28 @@ export function Checkout({
     if (order?.phase === "delivery") {
       onProcessingPayment();
     }
+    if (order?.phase) {
+      setCheckoutPhase(order.phase);
+    }
   }, [order, onPaymentCompleted, onProcessingPayment]);
+
+  // Listen for postMessage events from the embedded checkout to detect payment step
+  const handleMessage = useCallback((event: MessageEvent) => {
+    if (event.data?.type === "crossmint:checkout:stepChange") {
+      const currentStep = event.data?.step || "";
+      // Only show card helper on payment-related steps
+      setShowCardHelper(currentStep === "payment" || currentStep === "card");
+    }
+  }, []);
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, [handleMessage]);
+
+  // Determine if we should show the test card hint
+  const isPaymentStep = checkoutPhase === "payment" || checkoutPhase === "";
+  const shouldShowCardHelper = step === "options" && showCardHelper && isPaymentStep;
 
   return (
     <div
@@ -185,10 +211,19 @@ export function Checkout({
             </div>
           )}
           {orderId && clientSecret && !isCreatingOrder && (
-            <div>
-              {/* Test card info - hide when processing */}
+            <div className="flex flex-col gap-3">
+              {/* Sandbox environment notice */}
               {step === "options" && (
-                <div className="mb-4 flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
+                <div className="flex items-start gap-2 rounded-lg border border-amber-100 bg-amber-50/50 px-3 py-2">
+                  <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
+                  <span className="text-xs leading-relaxed text-amber-700">
+                    Sandbox mode — verification prompts can be skipped by selecting the pass option.
+                  </span>
+                </div>
+              )}
+              {/* Test card info - only show when payment card input is relevant */}
+              {shouldShowCardHelper && (
+                <div className="flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
                   <CreditCard className="h-4 w-4 flex-shrink-0 text-gray-500" />
                   <span className="text-xs text-gray-600">Test card:</span>
                   <code className="text-xs font-medium text-gray-800">4242 4242 4242 4242</code>
@@ -198,18 +233,20 @@ export function Checkout({
                   />
                 </div>
               )}
-              <CrossmintEmbeddedCheckout
-                orderId={orderId}
-                // @ts-ignore
-                clientSecret={clientSecret}
-                payment={{
-                  receiptEmail,
-                  crypto: { enabled: false },
-                  fiat: { enabled: true },
-                  defaultMethod: "fiat",
-                }}
-                appearance={CHECKOUT_APPEARANCE}
-              />
+              <div className="checkout-container overflow-hidden rounded-xl">
+                <CrossmintEmbeddedCheckout
+                  orderId={orderId}
+                  // @ts-ignore
+                  clientSecret={clientSecret}
+                  payment={{
+                    receiptEmail,
+                    crypto: { enabled: false },
+                    fiat: { enabled: true },
+                    defaultMethod: "fiat",
+                  }}
+                  appearance={CHECKOUT_APPEARANCE}
+                />
+              </div>
             </div>
           )}
         </div>

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -181,8 +181,7 @@ export function Checkout({
           )}
           {orderId && clientSecret && !isCreatingOrder && (
             <div className="flex flex-col gap-3">
-              {/* Show test card only once KYC is done and checkout reaches the payment phase */}
-              {order?.phase === "payment" && step === "options" && (
+              {step === "options" && (
                 <div className="flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
                   <CreditCard className="h-4 w-4 flex-shrink-0 text-gray-500" />
                   <span className="text-xs text-gray-600">Test card:</span>

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { CrossmintEmbeddedCheckout, useCrossmintCheckout } from "@crossmint/client-sdk-react-ui";
-import { CreditCard, Info } from "lucide-react";
+import { CreditCard } from "lucide-react";
 import { AmountBreakdown } from "./AmountBreakdown";
 import { cn } from "@/lib/utils";
 import { createOrder } from "@/server-actions/createOrder";
@@ -212,15 +212,6 @@ export function Checkout({
           )}
           {orderId && clientSecret && !isCreatingOrder && (
             <div className="flex flex-col gap-3">
-              {/* Sandbox environment notice */}
-              {step === "options" && (
-                <div className="flex items-start gap-2 rounded-lg border border-amber-100 bg-amber-50/50 px-3 py-2">
-                  <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-amber-500" />
-                  <span className="text-xs leading-relaxed text-amber-700">
-                    Sandbox mode — verification prompts can be skipped by selecting the pass option.
-                  </span>
-                </div>
-              )}
               {/* Test card info - only show when payment card input is relevant */}
               {shouldShowCardHelper && (
                 <div className="flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useRef, useState } from "react";
 import { CrossmintEmbeddedCheckout, useCrossmintCheckout } from "@crossmint/client-sdk-react-ui";
+import { CreditCard } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createOrder } from "@/server-actions/createOrder";
+import { CopyWrapper } from "../common/CopyWrapper";
 
 // Get CSS variables
 const primaryColor =
@@ -179,6 +181,18 @@ export function Checkout({
           )}
           {orderId && clientSecret && !isCreatingOrder && (
             <div className="flex flex-col gap-3">
+              {/* Show test card only once KYC is done and checkout reaches the payment phase */}
+              {order?.phase === "payment" && step === "options" && (
+                <div className="flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
+                  <CreditCard className="h-4 w-4 flex-shrink-0 text-gray-500" />
+                  <span className="text-xs text-gray-600">Test card:</span>
+                  <code className="text-xs font-medium text-gray-800">4242 4242 4242 4242</code>
+                  <CopyWrapper
+                    toCopy="4242424242424242"
+                    className="ml-auto text-xs text-gray-500 hover:text-gray-700"
+                  />
+                </div>
+              )}
               <div className="checkout-container overflow-hidden rounded-xl">
                 <CrossmintEmbeddedCheckout
                   orderId={orderId}

--- a/components/deposit/Checkout.tsx
+++ b/components/deposit/Checkout.tsx
@@ -1,10 +1,7 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { CrossmintEmbeddedCheckout, useCrossmintCheckout } from "@crossmint/client-sdk-react-ui";
-import { CreditCard } from "lucide-react";
-import { AmountBreakdown } from "./AmountBreakdown";
 import { cn } from "@/lib/utils";
 import { createOrder } from "@/server-actions/createOrder";
-import { CopyWrapper } from "../common/CopyWrapper";
 
 // Get CSS variables
 const primaryColor =
@@ -113,8 +110,6 @@ export function Checkout({
   const [clientSecret, setClientSecret] = useState<string>("");
   const [isCreatingOrder, setIsCreatingOrder] = useState(false);
   const [orderError, setOrderError] = useState<string>("");
-  const [showCardHelper, setShowCardHelper] = useState(true);
-  const [checkoutPhase, setCheckoutPhase] = useState<string>("");
   const orderAmountRef = useRef<string>("");
 
   const handleCreateOrder = async () => {
@@ -158,28 +153,7 @@ export function Checkout({
     if (order?.phase === "delivery") {
       onProcessingPayment();
     }
-    if (order?.phase) {
-      setCheckoutPhase(order.phase);
-    }
   }, [order, onPaymentCompleted, onProcessingPayment]);
-
-  // Listen for postMessage events from the embedded checkout to detect payment step
-  const handleMessage = useCallback((event: MessageEvent) => {
-    if (event.data?.type === "crossmint:checkout:stepChange") {
-      const currentStep = event.data?.step || "";
-      // Only show card helper on payment-related steps
-      setShowCardHelper(currentStep === "payment" || currentStep === "card");
-    }
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
-  }, [handleMessage]);
-
-  // Determine if we should show the test card hint
-  const isPaymentStep = checkoutPhase === "payment" || checkoutPhase === "";
-  const shouldShowCardHelper = step === "options" && showCardHelper && isPaymentStep;
 
   return (
     <div
@@ -188,13 +162,6 @@ export function Checkout({
         step !== "options" && "flex items-center justify-center"
       )}
     >
-      {step === "options" && (
-        <AmountBreakdown
-          quote={order?.lineItems[0].quote}
-          inputAmount={amount ? Number.parseFloat(amount) : 0}
-          isAmountValid={isAmountValid}
-        />
-      )}
       {amount && isAmountValid && (
         <div>
           {isCreatingOrder && (
@@ -212,18 +179,6 @@ export function Checkout({
           )}
           {orderId && clientSecret && !isCreatingOrder && (
             <div className="flex flex-col gap-3">
-              {/* Test card info - only show when payment card input is relevant */}
-              {shouldShowCardHelper && (
-                <div className="flex w-full items-center gap-2 rounded-lg bg-gray-50 px-3 py-2">
-                  <CreditCard className="h-4 w-4 flex-shrink-0 text-gray-500" />
-                  <span className="text-xs text-gray-600">Test card:</span>
-                  <code className="text-xs font-medium text-gray-800">4242 4242 4242 4242</code>
-                  <CopyWrapper
-                    toCopy="4242424242424242"
-                    className="ml-auto text-xs text-gray-500 hover:text-gray-700"
-                  />
-                </div>
-              )}
               <div className="checkout-container overflow-hidden rounded-xl">
                 <CrossmintEmbeddedCheckout
                   orderId={orderId}

--- a/components/deposit/index.tsx
+++ b/components/deposit/index.tsx
@@ -26,12 +26,17 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
   const { user } = useCrossmintAuth();
   const receiptEmail = user?.email;
   const [amount, setAmount] = useState("");
+  const [confirmedAmount, setConfirmedAmount] = useState("");
   const { refetch: refetchActivityFeed } = useActivityFeed();
   const { refetch: refetchBalance } = useBalance();
+
+  const isAmountValid = Number(amount) >= MIN_AMOUNT && Number(amount) <= MAX_AMOUNT;
+  const hasConfirmedAmount = confirmedAmount !== "" && isAmountValid;
 
   const restartFlow = () => {
     setStep("options");
     setAmount("");
+    setConfirmedAmount("");
   };
 
   const handleDone = () => {
@@ -49,14 +54,28 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
     setStep("processing");
   }, []);
 
+  const handleAmountConfirm = () => {
+    if (isAmountValid) {
+      setConfirmedAmount(amount);
+    }
+  };
+
   const showCloseButton = step === "options";
+
+  // Show amount in title once confirmed
+  const titleText =
+    hasConfirmedAmount && step === "options"
+      ? `Deposit $${confirmedAmount}`
+      : step === "processing"
+        ? "Processing..."
+        : "Deposit";
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
       <DialogContent className="flex max-h-[85vh] min-h-[580px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
         {showCloseButton && <DialogClose />}
-        <DialogTitle className="text-center">Deposit</DialogTitle>
-        {step === "options" && (
+        <DialogTitle className="text-center">{titleText}</DialogTitle>
+        {step === "options" && !hasConfirmedAmount && (
           <div className="mb-6 flex w-full flex-col items-center">
             <AmountInput amount={amount} onChange={setAmount} />
             {Number(amount) > 0 && Number(amount) < MIN_AMOUNT && (
@@ -69,14 +88,23 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
                 Transaction amount exceeds the maximum allowed deposit limit of ${MAX_AMOUNT}
               </div>
             )}
+            {isAmountValid && (
+              <button
+                type="button"
+                onClick={handleAmountConfirm}
+                className="bg-primary hover:bg-primary-hover text-primary-foreground mt-4 w-full rounded-full px-6 py-3 text-sm font-medium transition"
+              >
+                Continue with ${amount}
+              </button>
+            )}
           </div>
         )}
         <div className="flex w-full flex-grow flex-col">
           <CrossmintProvider apiKey={CLIENT_API_KEY_CONSOLE_FUND as string}>
             <CrossmintCheckoutProvider>
               <Checkout
-                amount={amount}
-                isAmountValid={Number(amount) >= MIN_AMOUNT && Number(amount) <= MAX_AMOUNT}
+                amount={confirmedAmount}
+                isAmountValid={hasConfirmedAmount}
                 walletAddress={walletAddress}
                 onPaymentCompleted={handlePaymentCompleted}
                 receiptEmail={receiptEmail || ""}

--- a/components/deposit/index.tsx
+++ b/components/deposit/index.tsx
@@ -73,7 +73,7 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="flex max-h-[90vh] min-h-[480px] sm:min-h-[700px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
+      <DialogContent className="flex max-h-[85vh] min-h-[580px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
         {showCloseButton && <DialogClose />}
         <DialogTitle className="text-center">{titleText}</DialogTitle>
         {step === "options" && !hasConfirmedAmount && (

--- a/components/deposit/index.tsx
+++ b/components/deposit/index.tsx
@@ -103,6 +103,9 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
             )}
           </div>
         )}
+        {step === "options" && hasConfirmedAmount && (
+          <AmountBreakdown inputAmount={Number(confirmedAmount)} isAmountValid={true} />
+        )}
         <div className="flex w-full flex-grow flex-col">
           <CrossmintProvider apiKey={CLIENT_API_KEY_CONSOLE_FUND as string}>
             <CrossmintCheckoutProvider>

--- a/components/deposit/index.tsx
+++ b/components/deposit/index.tsx
@@ -73,7 +73,7 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="flex max-h-[95vh] min-h-[700px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
+      <DialogContent className="flex max-h-[90vh] min-h-[480px] sm:min-h-[700px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
         {showCloseButton && <DialogClose />}
         <DialogTitle className="text-center">{titleText}</DialogTitle>
         {step === "options" && !hasConfirmedAmount && (

--- a/components/deposit/index.tsx
+++ b/components/deposit/index.tsx
@@ -73,7 +73,7 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DialogContent className="flex max-h-[85vh] min-h-[580px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
+      <DialogContent className="flex max-h-[95vh] min-h-[700px] flex-col overflow-y-auto rounded-3xl bg-white sm:max-w-md">
         {showCloseButton && <DialogClose />}
         <DialogTitle className="text-center">{titleText}</DialogTitle>
         {step === "options" && !hasConfirmedAmount && (

--- a/components/deposit/index.tsx
+++ b/components/deposit/index.tsx
@@ -5,6 +5,7 @@ import {
   useCrossmintAuth,
 } from "@crossmint/client-sdk-react-ui";
 import { Checkout } from "./Checkout";
+import { AmountBreakdown } from "./AmountBreakdown";
 import { AmountInput } from "../common/AmountInput";
 import { Dialog, DialogContent, DialogTitle, DialogClose } from "../common/Dialog";
 import { useActivityFeed } from "../../hooks/useActivityFeed";
@@ -76,7 +77,7 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
         {showCloseButton && <DialogClose />}
         <DialogTitle className="text-center">{titleText}</DialogTitle>
         {step === "options" && !hasConfirmedAmount && (
-          <div className="mb-6 flex w-full flex-col items-center">
+          <div className="mb-6 flex w-full flex-col items-center gap-4">
             <AmountInput amount={amount} onChange={setAmount} />
             {Number(amount) > 0 && Number(amount) < MIN_AMOUNT && (
               <div className="mt-1 text-center text-red-600">
@@ -89,13 +90,16 @@ export function DepositModal({ open, onClose, walletAddress }: DepositModalProps
               </div>
             )}
             {isAmountValid && (
-              <button
-                type="button"
-                onClick={handleAmountConfirm}
-                className="bg-primary hover:bg-primary-hover text-primary-foreground mt-4 w-full rounded-full px-6 py-3 text-sm font-medium transition"
-              >
-                Continue with ${amount}
-              </button>
+              <>
+                <AmountBreakdown inputAmount={Number(amount)} isAmountValid={isAmountValid} />
+                <button
+                  type="button"
+                  onClick={handleAmountConfirm}
+                  className="bg-primary hover:bg-primary-hover text-primary-foreground w-full rounded-full px-6 py-3 text-sm font-medium transition"
+                >
+                  Continue with ${amount}
+                </button>
+              </>
             )}
           </div>
         )}


### PR DESCRIPTION
## Summary

Fixes DVRL-1284 — UX/layout issues in the onramp deposit modal.

**Infinite loading for amount/fees/total:** `AmountBreakdown` falls back to estimated values (marked with `~`) after a 5s timeout when the quote doesn't resolve. Uses ~2.9% + $0.99 estimated fees when the sandbox returns zero fees (`totalPrice == upperBound`).

**Deposit amount mismatch:** Two-step confirmation flow — user enters amount → confirms via "Continue with $X" → amount locks, title updates to "Deposit $X", and `Checkout` receives `confirmedAmount` instead of the live input.

**Rounded checkout CTA:** `borderRadius: "9999px"` on `PrimaryButton` in `CHECKOUT_APPEARANCE`.

**`AmountBreakdown` moved to parent:** Removed from `Checkout.tsx`, now rendered in `index.tsx` during amount entry (live estimates) and after confirmation. Only shown when `isAmountValid` (amount ≥ $1).

**Not addressed (requires SDK/product changes):**
- Test card helper scoped to payment step only (SDK doesn't expose `order.phase` transitions reliably in sandbox)
- Persona/KYC separated into distinct modal (bundled inside `CrossmintEmbeddedCheckout` iframe)
- Overlapping CTA / "pass verifications" slider (layout inside Persona's form within checkout iframe)
- Sandbox warning presentation (rendered inside the checkout iframe)

Link to Devin session: https://crossmint.devinenterprise.com/sessions/94915e79782b4e90bcc4b87dccfcc894
Requested by: @jmderby